### PR TITLE
PlanetFactory support & planetary parameter overrides

### DIFF
--- a/FNPlugin/AntimatterCollector.cs
+++ b/FNPlugin/AntimatterCollector.cs
@@ -29,7 +29,7 @@ namespace FNPlugin {
                 double lat = vessel.mainBody.GetLatitude(vessel.transform.position);
                 double vessel_avg_alt = (vessel.orbit.ApR + vessel.orbit.PeR) / 2.0f;
                 double vessel_inclination = vessel.orbit.inclination;
-				float flux = (VanAllen.getBeltAntiparticles(vessel.mainBody.flightGlobalsIndex, (float)vessel_avg_alt, (float)vessel_inclination) + VanAllen.getBeltAntiparticles(vessel.mainBody.flightGlobalsIndex, (float)vessel_avg_alt, 0.0f))/2.0f;
+				float flux = (VanAllen.getBeltAntiparticles(vessel.mainBody, (float)vessel_avg_alt, (float)vessel_inclination) + VanAllen.getBeltAntiparticles(vessel.mainBody, (float)vessel_avg_alt, 0.0f))/2.0f;
                 //vessel.orbit.
                 double antimatter_to_add = time_diff*flux;
                 //part.RequestResource("Antimatter", -antimatter_to_add);
@@ -39,7 +39,7 @@ namespace FNPlugin {
 
         public override void OnUpdate() {
             float lat = (float)vessel.mainBody.GetLatitude(this.vessel.GetWorldPos3D());
-            float flux = VanAllen.getBeltAntiparticles(vessel.mainBody.flightGlobalsIndex, (float)vessel.altitude, lat);
+            float flux = VanAllen.getBeltAntiparticles(vessel.mainBody, (float)vessel.altitude, lat);
             ParticleFlux = flux.ToString("E");
             collectionRate = collection_rate_d.ToString("0.00") + " mg/day";
         }
@@ -47,7 +47,7 @@ namespace FNPlugin {
         public override void OnFixedUpdate() {
             drawCount++;
             float lat = (float) vessel.mainBody.GetLatitude(this.vessel.GetWorldPos3D());
-            float flux = VanAllen.getBeltAntiparticles(vessel.mainBody.flightGlobalsIndex, (float)vessel.altitude,lat);
+            float flux = VanAllen.getBeltAntiparticles(vessel.mainBody, (float)vessel.altitude,lat);
             //part.RequestResource("Antimatter", -flux * TimeWarp.fixedDeltaTime);
             ORSHelper.fixedRequestResource(part, "Antimatter", -flux * TimeWarp.fixedDeltaTime);
             last_active_time = (float)Planetarium.GetUniversalTime();

--- a/FNPlugin/ComputerCore.cs
+++ b/FNPlugin/ComputerCore.cs
@@ -106,7 +106,7 @@ namespace FNPlugin {
 				float altitude_multiplier = (float)(vessel.altitude / (vessel.mainBody.Radius));
 				altitude_multiplier = Math.Max (altitude_multiplier, 1);
 
-				double science_to_add = baseScienceRate * time_diff / 86400 * electrical_power_ratio * PluginHelper.getScienceMultiplier (vessel.mainBody.flightGlobalsIndex,vessel.LandedOrSplashed) / ((float)Math.Sqrt (altitude_multiplier));
+				double science_to_add = baseScienceRate * time_diff / 86400 * electrical_power_ratio * PluginHelper.getScienceMultiplier (vessel.mainBody.name, vessel.LandedOrSplashed) / ((float)Math.Sqrt (altitude_multiplier));
                 science_awaiting_addition = science_to_add;
                 
 				var curReaction = this.part.Modules["ModuleReactionWheel"] as ModuleReactionWheel;
@@ -163,7 +163,7 @@ namespace FNPlugin {
 				electrical_power_ratio = power_returned / upgradedMegajouleRate;
 				float altitude_multiplier = (float) (vessel.altitude / (vessel.mainBody.Radius));
 				altitude_multiplier = Math.Max(altitude_multiplier, 1);
-				science_rate_f = baseScienceRate * PluginHelper.getScienceMultiplier(vessel.mainBody.flightGlobalsIndex,vessel.LandedOrSplashed) / 86400 * power_returned/upgradedMegajouleRate / ((float)Math.Sqrt(altitude_multiplier));
+				science_rate_f = baseScienceRate * PluginHelper.getScienceMultiplier(vessel.mainBody.name, vessel.LandedOrSplashed) / 86400 * power_returned/upgradedMegajouleRate / ((float)Math.Sqrt(altitude_multiplier));
 				//part.RequestResource("Science", -science_rate_f * TimeWarp.fixedDeltaTime);
 				if (ResearchAndDevelopment.Instance != null) {
 					ResearchAndDevelopment.Instance.Science = ResearchAndDevelopment.Instance.Science + science_rate_f * TimeWarp.fixedDeltaTime;

--- a/FNPlugin/DTMagnetometer.cs
+++ b/FNPlugin/DTMagnetometer.cs
@@ -86,10 +86,10 @@ namespace FNPlugin {
 			Fields["ParticleFlux"].guiActive = IsEnabled;
 
             float lat = (float)vessel.mainBody.GetLatitude(this.vessel.GetWorldPos3D());
-            float Bmagf = VanAllen.getBeltMagneticFieldMag(vessel.mainBody.flightGlobalsIndex, (float)vessel.altitude, lat);
-            float Bradf = VanAllen.getBeltMagneticFieldRadial(vessel.mainBody.flightGlobalsIndex, (float)vessel.altitude, lat);
-            float Bthef = VanAllen.getBeltMagneticFieldAzimuthal(vessel.mainBody.flightGlobalsIndex, (float)vessel.altitude, lat);
-            float flux = VanAllen.getBeltAntiparticles(vessel.mainBody.flightGlobalsIndex, (float)vessel.altitude, lat);
+            float Bmagf = VanAllen.getBeltMagneticFieldMag(vessel.mainBody, (float)vessel.altitude, lat);
+            float Bradf = VanAllen.getBeltMagneticFieldRadial(vessel.mainBody, (float)vessel.altitude, lat);
+            float Bthef = VanAllen.getBeltMagneticFieldAzimuthal(vessel.mainBody, (float)vessel.altitude, lat);
+            float flux = VanAllen.getBeltAntiparticles(vessel.mainBody, (float)vessel.altitude, lat);
             Bmag = Bmagf.ToString("E") + "T";
             Brad = Bradf.ToString("E") + "T";
             Bthe = Bthef.ToString("E") + "T";

--- a/FNPlugin/FNImpactorModule.cs
+++ b/FNPlugin/FNImpactorModule.cs
@@ -134,15 +134,15 @@ namespace FNPlugin {
                     }
 
                     // do sciency stuff
-                    Vector3d surface_vector = (conf_vess.transform.position - FlightGlobals.Bodies[body].transform.position);
+                    Vector3d surface_vector = (conf_vess.transform.position - vessel.mainBody.transform.position);
                     surface_vector = surface_vector.normalized;
                     if (first) {
                         first = false;
                         net_vector = surface_vector;
-                        net_science = 50 * PluginHelper.getImpactorScienceMultiplier(body);
+                        net_science = 50 * PluginHelper.getImpactorScienceMultiplier(vessel.mainBody.name);
                         initial_science = net_science;
                     } else {
-                        net_science += (1.0 - Vector3d.Dot(surface_vector, net_vector.normalized)) * 50 * PluginHelper.getImpactorScienceMultiplier(body);
+                        net_science += (1.0 - Vector3d.Dot(surface_vector, net_vector.normalized)) * 50 * PluginHelper.getImpactorScienceMultiplier(vessel.mainBody.name);
                         net_vector = net_vector + surface_vector;
                     }
                 }

--- a/FNPlugin/FNSeismicProbe.cs
+++ b/FNPlugin/FNSeismicProbe.cs
@@ -91,11 +91,11 @@ namespace FNPlugin {
                             recovery_value = science_amount;
                             subject.subjectValue = 1;
                             subject.scientificValue = 1;
-                            subject.scienceCap = 50 * PluginHelper.getImpactorScienceMultiplier(vessel.mainBody.flightGlobalsIndex)*10;
+                            subject.scienceCap = 50 * PluginHelper.getImpactorScienceMultiplier(vessel.mainBody.name)*10;
                             //subject.science = 0;
                             data_size = science_amount * 2.5f;
                             science_data = new ScienceData(science_amount, 1, 0, subject.id, "Impactor Data");
-                            ref_value = 50*PluginHelper.getImpactorScienceMultiplier(vessel.mainBody.flightGlobalsIndex);
+                            ref_value = 50*PluginHelper.getImpactorScienceMultiplier(vessel.mainBody.name);
                             return true;
                         }
                     }

--- a/FNPlugin/PluginHelper.cs
+++ b/FNPlugin/PluginHelper.cs
@@ -241,6 +241,17 @@ namespace FNPlugin {
 			}else {
 				multiplier = 0f;
 			}
+        public static string getPropertyOverrideForBody(string name, string type)
+        {
+            ConfigNode scienceOverrides = getPluginSettingsFile().GetNode("WARP_PLUGIN_PLANET_OVERRIDES");
+            if (scienceOverrides != null)
+            {
+                ConfigNode scienceOverride = scienceOverrides.GetNode(name);
+                if (scienceOverride != null && scienceOverride.HasValue(type))
+                    return scienceOverride.GetValue(type);
+            }
+            return null;
+        }
 
 			if (landed) {
 				if (refbody == REF_BODY_TYLO) {
@@ -281,6 +292,8 @@ namespace FNPlugin {
         public static double getSpecialMagneticFieldScaling(string name)
         {
             float scaling = DEFAULT_MAGNETIC_SCALING.ContainsKey(name) ? DEFAULT_MAGNETIC_SCALING[name] : 1.0f;
+            string scalingOverride = getPropertyOverrideForBody(name, "magneticScaling");
+            if (scalingOverride != null) scaling = float.Parse(scalingOverride);
             return scaling;
         }
 

--- a/FNPlugin/PluginHelper.cs
+++ b/FNPlugin/PluginHelper.cs
@@ -9,6 +9,8 @@ namespace FNPlugin {
     [KSPAddon(KSPAddon.Startup.SpaceCentre, false)]
 	public class PluginHelper : MonoBehaviour {
         public const double FIXED_SAT_ALTITUDE = 13599840256;
+        public static Dictionary<string, float> DEFAULT_MAGNETIC_SCALING = new Dictionary<string, float>();
+
         public const int REF_BODY_KERBOL = 0;
         public const int REF_BODY_KERBIN = 1;
         public const int REF_BODY_MUN = 2;
@@ -50,6 +52,20 @@ namespace FNPlugin {
         protected static int installed_tech_tree_version_id = 0;
         protected static int new_tech_tree_version_id = 0;
         
+
+        private void SetupDefaultScience()
+        {
+            DEFAULT_MAGNETIC_SCALING.Add("Tylo", 7f);
+            DEFAULT_MAGNETIC_SCALING.Add("Laythe", 5f);
+            DEFAULT_MAGNETIC_SCALING.Add("Moho", 2f);
+            DEFAULT_MAGNETIC_SCALING.Add("Jool", 3f);
+            DEFAULT_MAGNETIC_SCALING.Add("Eve", 2f);
+            DEFAULT_MAGNETIC_SCALING.Add("Mun", 0.2f);
+            DEFAULT_MAGNETIC_SCALING.Add("Ike", 0.2f);
+            DEFAULT_MAGNETIC_SCALING.Add("Gilly", 0.05f);
+            DEFAULT_MAGNETIC_SCALING.Add("Bop", 0.05f);
+            DEFAULT_MAGNETIC_SCALING.Add("Pol", 0.05f);
+        }
         
         
         public static string getPluginSaveFilePath() {
@@ -262,7 +278,15 @@ namespace FNPlugin {
             return multiplier;
         }
 
+        public static double getSpecialMagneticFieldScaling(string name)
+        {
+            float scaling = DEFAULT_MAGNETIC_SCALING.ContainsKey(name) ? DEFAULT_MAGNETIC_SCALING[name] : 1.0f;
+            return scaling;
+        }
+
         public void Start() {
+            SetupDefaultScience();
+
             tech_window = new TechUpdateWindow();
             tech_checked = false;
 

--- a/FNPlugin/ScienceModule.cs
+++ b/FNPlugin/ScienceModule.cs
@@ -183,7 +183,7 @@ namespace FNPlugin {
                         stupidity += proto_crew_member.stupidity;
                     }
                     stupidity = 1.5f - stupidity / 2.0f;
-                    double science_to_add = GameConstants.baseScienceRate * time_diff / 86400 * electrical_power_ratio * stupidity * global_rate_multipliers * PluginHelper.getScienceMultiplier(vessel.mainBody.flightGlobalsIndex, vessel.LandedOrSplashed) / ((float)Math.Sqrt(altitude_multiplier));
+                    double science_to_add = GameConstants.baseScienceRate * time_diff / 86400 * electrical_power_ratio * stupidity * global_rate_multipliers * PluginHelper.getScienceMultiplier(vessel.mainBody.name, vessel.LandedOrSplashed) / ((float)Math.Sqrt(altitude_multiplier));
                     //part.RequestResource ("Science", -science_to_add);
                     science_awaiting_addition = science_to_add;
 
@@ -319,7 +319,7 @@ namespace FNPlugin {
                     stupidity = 1.5f - stupidity / 2.0f;
                     float altitude_multiplier = (float)(vessel.altitude / (vessel.mainBody.Radius));
                     altitude_multiplier = Math.Max(altitude_multiplier, 1);
-                    science_rate_f = (float)(GameConstants.baseScienceRate * PluginHelper.getScienceMultiplier(vessel.mainBody.flightGlobalsIndex, vessel.LandedOrSplashed) / 86400.0f * global_rate_multipliers * stupidity / (Mathf.Sqrt(altitude_multiplier)));
+                    science_rate_f = (float)(GameConstants.baseScienceRate * PluginHelper.getScienceMultiplier(vessel.mainBody.name, vessel.LandedOrSplashed) / 86400.0f * global_rate_multipliers * stupidity / (Mathf.Sqrt(altitude_multiplier)));
                     if (ResearchAndDevelopment.Instance != null) {
                         if (!double.IsNaN(science_rate_f) && !double.IsInfinity(science_rate_f)) {
                             ResearchAndDevelopment.Instance.Science = ResearchAndDevelopment.Instance.Science + science_rate_f * TimeWarp.fixedDeltaTime;

--- a/FNPlugin/VanAllen.cs
+++ b/FNPlugin/VanAllen.cs
@@ -81,7 +81,7 @@ namespace FNPlugin {
             CelestialBody cur_ref_body = FlightGlobals.ActiveVessel.mainBody;
             CelestialBody crefkerbin = FlightGlobals.fetch.bodies[1];
 
-            ORSPlanetaryResourcePixel res_pixel = ORSPlanetaryResourceMapData.getResourceAvailability(vessel.mainBody.flightGlobalsIndex, "Thorium", cur_ref_body.GetLatitude(vessel.transform.position), cur_ref_body.GetLongitude(vessel.transform.position));
+            ORSPlanetaryResourcePixel res_pixel = ORSPlanetaryResourceMapData.getResourceAvailability(vessel.mainBody, "Thorium", cur_ref_body.GetLatitude(vessel.transform.position), cur_ref_body.GetLongitude(vessel.transform.position));
             double ground_rad = Math.Sqrt(res_pixel.getAmount() * 9e6) / 24 / 365.25 / Math.Max(vessel.altitude / 870, 1);
             double rad = VanAllen.getRadiationLevel(cur_ref_body.flightGlobalsIndex, (float)FlightGlobals.ship_altitude, (float)FlightGlobals.ship_latitude);
             double divisor = Math.Pow(cur_ref_body.Radius / crefkerbin.Radius, 2.0);

--- a/GameData/WarpPlugin/WarpPluginSettings.cfg
+++ b/GameData/WarpPlugin/WarpPluginSettings.cfg
@@ -11,3 +11,13 @@ WARP_PLUGIN_SETTINGS
 	AmmoniaResourceName = Ammonia
 	ThermalMechanicsDisabled = False
 }
+WARP_PLUGIN_PLANET_OVERRIDES
+{
+	DummyPlanet
+	{
+		scienceBase = 1
+		scienceLanded = 1
+		scienceImpactor = 1
+		magneticScaling = 1.5
+	}
+}

--- a/OpenResourceSystem/ORSModuleResourceExtraction.cs
+++ b/OpenResourceSystem/ORSModuleResourceExtraction.cs
@@ -67,7 +67,7 @@ namespace OpenResourceSystem {
                 double resource_abundance = 0;
                 bool resource_available = false;
                 if (vessel.Landed) {
-                    ORSPlanetaryResourcePixel current_resource_abundance_pixel = ORSPlanetaryResourceMapData.getResourceAvailabilityByRealResourceName(vessel.mainBody.flightGlobalsIndex, resourceName, vessel.latitude, vessel.longitude);
+                    ORSPlanetaryResourcePixel current_resource_abundance_pixel = ORSPlanetaryResourceMapData.getResourceAvailabilityByRealResourceName(vessel.mainBody, resourceName, vessel.latitude, vessel.longitude);
                     resource_abundance = current_resource_abundance_pixel.getAmount();
                 } else if (vessel.Splashed) {
                     resource_abundance = ORSOceanicResourceHandler.getOceanicResourceContent(vessel.mainBody.flightGlobalsIndex, resourceName);
@@ -132,7 +132,7 @@ namespace OpenResourceSystem {
                 }
                 double resource_abundance = 0;
                 if (vessel.Landed) {
-                    ORSPlanetaryResourcePixel current_resource_abundance_pixel = ORSPlanetaryResourceMapData.getResourceAvailabilityByRealResourceName(vessel.mainBody.flightGlobalsIndex, resourceName, vessel.latitude, vessel.longitude);
+                    ORSPlanetaryResourcePixel current_resource_abundance_pixel = ORSPlanetaryResourceMapData.getResourceAvailabilityByRealResourceName(vessel.mainBody, resourceName, vessel.latitude, vessel.longitude);
                     resource_abundance = current_resource_abundance_pixel.getAmount();
                 } else if (vessel.Splashed) {
                     resource_abundance = ORSOceanicResourceHandler.getOceanicResourceContent(vessel.mainBody.flightGlobalsIndex, resourceName);

--- a/OpenResourceSystem/ORSPlanetaryResourceMapData.cs
+++ b/OpenResourceSystem/ORSPlanetaryResourceMapData.cs
@@ -23,8 +23,9 @@ namespace OpenResourceSystem {
         static double stored_scale = -1;
         
 
-        public static void loadPlanetaryResourceData(int body) {
-            string celestial_body_name = FlightGlobals.Bodies[body].bodyName;
+        public static void loadPlanetaryResourceData(CelestialBody cbody) {
+            int body = cbody.flightGlobalsIndex;
+            string celestial_body_name = cbody.bodyName;
             UrlDir.UrlConfig[] configs = GameDatabase.Instance.GetConfigs("PLANETARY_RESOURCE_DEFINITION");
             Debug.Log("[ORS] Loading Planetary Resource Data. Length: " + configs.Length);
             foreach (ORSResourceAbundanceMarker abundance_marker in abundance_markers) {
@@ -114,22 +115,26 @@ namespace OpenResourceSystem {
             return resource_val;
         }
 
-        public static ORSPlanetaryResourcePixel getResourceAvailabilityByRealResourceName(int body, string resourcename, double lat, double lng) {
+        public static ORSPlanetaryResourcePixel getResourceAvailabilityByRealResourceName(CelestialBody cbody, string resourcename, double lat, double lng)
+        {
+            int body = cbody.flightGlobalsIndex;
             if (body != current_body) {
-                loadPlanetaryResourceData(body);
+                loadPlanetaryResourceData(cbody);
             }
             try{
                 ORSPlanetaryResourceInfo resource_info = body_resource_maps.Where(ri => ri.Value.getResourceName() == resourcename).FirstOrDefault().Value;
-                return getResourceAvailability(body, resource_info.getName(),lat,lng);
+                return getResourceAvailability(cbody, resource_info.getName(),lat,lng);
             }catch(Exception ex) {
                 ORSPlanetaryResourcePixel resource_pixel = new ORSPlanetaryResourcePixel(resourcename, 0, body);
                 return resource_pixel;
             }
         }
 
-        public static ORSPlanetaryResourcePixel getResourceAvailability(int body, string resourcename, double lat, double lng) {
+        public static ORSPlanetaryResourcePixel getResourceAvailability(CelestialBody cbody, string resourcename, double lat, double lng)
+        {
+            int body = cbody.flightGlobalsIndex;
             if (body != current_body) {
-                loadPlanetaryResourceData(body);
+                loadPlanetaryResourceData(cbody);
             }
             int lng_s = ((int)Math.Ceiling(Math.Abs(lng / 180)) % 2);
             lng = lng % 180;
@@ -190,7 +195,7 @@ namespace OpenResourceSystem {
 
         public static void updatePlanetaryResourceMap() {
             if (FlightGlobals.currentMainBody.flightGlobalsIndex != current_body) {
-                loadPlanetaryResourceData(FlightGlobals.currentMainBody.flightGlobalsIndex);
+                loadPlanetaryResourceData(FlightGlobals.currentMainBody);
             }
 
             if (body_resource_maps.ContainsKey(displayed_resource) && (FlightGlobals.currentMainBody.flightGlobalsIndex != map_body || displayed_resource != map_resource)) {

--- a/OpenResourceSystem/ORSResourceScanner.cs
+++ b/OpenResourceSystem/ORSResourceScanner.cs
@@ -47,7 +47,7 @@ namespace OpenResourceSystem {
 
         public override void OnFixedUpdate() {
             CelestialBody body = vessel.mainBody;
-            ORSPlanetaryResourcePixel res_pixel = ORSPlanetaryResourceMapData.getResourceAvailability(vessel.mainBody.flightGlobalsIndex, resourceName, body.GetLatitude(vessel.transform.position), body.GetLongitude(vessel.transform.position));
+            ORSPlanetaryResourcePixel res_pixel = ORSPlanetaryResourceMapData.getResourceAvailability(vessel.mainBody, resourceName, body.GetLatitude(vessel.transform.position), body.GetLongitude(vessel.transform.position));
             abundance = res_pixel.getAmount();
         }
 


### PR DESCRIPTION
PlanetFactory uses bogus **CelestialBody.flightGlobalIndex** values, to (i think) maintain savegame integrity when planet packs are added or removed on the fly. This breaks an assumption made in Interstellar and ORS, and its special features do not work on these bodies.

I changed some method parameters to get around this, and now lab science, impactor experiments, radiation and resources (did not test this last one though) "just work" everywhere, and there's no more endless log trash. I had to change the ORS API unfortunately, which may or may not be a problem, since currently only Interstellar uses it (AFAIK).

I also added the possibility to change science rates and magnetic field scales via config (currently in WarpPlugin.cfg), to allow these features to actually be used since they only have defaults for the vanilla system. This also allows tweaking for Alternis Kerbol.

I submitted against this repo since this is the version my career save (=test case) is made in, but I could rebase it if needed.
