### PR TITLE
Throttle MJ consumption based on actual refinement and extraction output.

### DIFF
--- a/FNPlugin/FNRefinery.cs
+++ b/FNPlugin/FNRefinery.cs
@@ -253,10 +253,20 @@ namespace FNPlugin {
                     double oxygen_density = PartResourceLibrary.Instance.GetDefinition(PluginHelper.oxygen_resource_name).density;
                     electrolysis_rate_d = electrical_power_provided / GameConstants.aluminiumElectrolysisEnergyPerTon / TimeWarp.fixedDeltaTime;
                     double alumina_consumption_rate = part.RequestResource("Alumina", electrolysis_rate_d * TimeWarp.fixedDeltaTime / density_alumina) / TimeWarp.fixedDeltaTime * density_alumina;
-                    double mass_rate = alumina_consumption_rate;
-                    electrolysis_rate_d = part.RequestResource(PluginHelper.aluminium_resource_name, -mass_rate * TimeWarp.fixedDeltaTime / aluminium_density) * aluminium_density;
-                    electrolysis_rate_d += part.RequestResource(PluginHelper.oxygen_resource_name, -GameConstants.aluminiumElectrolysisMassRatio * mass_rate * TimeWarp.fixedDeltaTime / oxygen_density) * oxygen_density;
-                    electrolysis_rate_d = electrolysis_rate_d / TimeWarp.fixedDeltaTime;
+		    if (alumina_consumption_rate <= 0) { // none to convert
+		      consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+		      electrolysis_rate_d = 0;
+		    } else {
+		      double mass_rate = alumina_consumption_rate;
+		      electrolysis_rate_d = part.RequestResource(PluginHelper.aluminium_resource_name, -mass_rate * TimeWarp.fixedDeltaTime / aluminium_density) * aluminium_density;
+		      electrolysis_rate_d += part.RequestResource(PluginHelper.oxygen_resource_name, -GameConstants.aluminiumElectrolysisMassRatio * mass_rate * TimeWarp.fixedDeltaTime / oxygen_density) * oxygen_density;
+		      if (electrolysis_rate_d <= 0) { //no where to store it
+			consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+			electrolysis_rate_d = 0;
+		      } else {
+			electrolysis_rate_d = electrolysis_rate_d / TimeWarp.fixedDeltaTime;
+		      }
+		    }
                 } else if (active_mode == 2) { // Sabatier ISRU
                     if (FlightGlobals.getStaticPressure(vessel.transform.position) * ORSAtmosphericResourceHandler.getAtmosphericResourceContentByDisplayName(vessel.mainBody.flightGlobalsIndex, "Carbon Dioxide") >= 0.01) {
                         double electrical_power_provided = consumeFNResource((GameConstants.baseELCPowerConsumption) * TimeWarp.fixedDeltaTime, FNResourceManager.FNRESOURCE_MEGAJOULES);
@@ -272,7 +282,14 @@ namespace FNPlugin {
                             double o_rate = part.RequestResource(PluginHelper.oxygen_resource_name, -oxygen_rate * TimeWarp.fixedDeltaTime / density_o);
                             double methane_rate = oxygen_rate * 2;
                             methane_rate_d = -part.RequestResource(PluginHelper.methane_resource_name, -methane_rate * TimeWarp.fixedDeltaTime / density_ch4) * density_ch4 / TimeWarp.fixedDeltaTime;
-                        }
+			    if (methane_rate_d >= 0) { //no where to store it
+			      consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+			      methane_rate_d = 0;
+			    }
+                        } else { //none to convert
+			  consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+			  h2_rate = 0;
+			}
                     } else {
                         ScreenMessages.PostScreenMessage("Ambient C02 insufficient.", 5.0f, ScreenMessageStyle.UPPER_CENTER);
                         IsEnabled = false;
@@ -285,11 +302,21 @@ namespace FNPlugin {
                     electrical_power_ratio = (float)(electrical_power_provided / TimeWarp.fixedDeltaTime / GameConstants.baseELCPowerConsumption);
                     electrolysis_rate_d = electrical_power_provided / GameConstants.electrolysisEnergyPerTon / TimeWarp.fixedDeltaTime;
                     double water_consumption_rate = part.RequestResource(PluginHelper.water_resource_name, electrolysis_rate_d * TimeWarp.fixedDeltaTime / density_h2o) / TimeWarp.fixedDeltaTime*density_h2o;
-                    double hydrogen_rate = water_consumption_rate / (1 + GameConstants.electrolysisMassRatio);
-                    double oxygen_rate = hydrogen_rate * GameConstants.electrolysisMassRatio;
-                    electrolysis_rate_d = part.RequestResource(PluginHelper.hydrogen_resource_name, -hydrogen_rate * TimeWarp.fixedDeltaTime / density_h);
-                    electrolysis_rate_d += part.RequestResource(PluginHelper.oxygen_resource_name, -oxygen_rate * TimeWarp.fixedDeltaTime / density_o);
-                    electrolysis_rate_d = electrolysis_rate_d / TimeWarp.fixedDeltaTime * density_h;
+		    if (water_consumption_rate <= 0) { // none to convert
+		      electrolysis_rate_d = 0;
+		      consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+		    } else {
+		      double hydrogen_rate = water_consumption_rate / (1 + GameConstants.electrolysisMassRatio);
+		      double oxygen_rate = hydrogen_rate * GameConstants.electrolysisMassRatio;
+		      electrolysis_rate_d = part.RequestResource(PluginHelper.hydrogen_resource_name, -hydrogen_rate * TimeWarp.fixedDeltaTime / density_h);
+		      electrolysis_rate_d += part.RequestResource(PluginHelper.oxygen_resource_name, -oxygen_rate * TimeWarp.fixedDeltaTime / density_o);
+		      if (electrolysis_rate_d <= 0) { // no where to store it
+			consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+			electrolysis_rate_d = 0;
+		      } else {
+			electrolysis_rate_d = electrolysis_rate_d / TimeWarp.fixedDeltaTime * density_h;
+		      }
+		    }
                 } else if (active_mode == 4) { // Anthraquinone Process
                     double density_h2o = PartResourceLibrary.Instance.GetDefinition(PluginHelper.water_resource_name).density;
                     double density_h2o2 = PartResourceLibrary.Instance.GetDefinition(PluginHelper.hydrogen_peroxide_resource_name).density;
@@ -301,7 +328,10 @@ namespace FNPlugin {
                     if (water_consumption_rate <= 0 && electrical_power_ratio > 0) {
                         ScreenMessages.PostScreenMessage("Water is required to perform the Anthraquinone Process.", 5.0f, ScreenMessageStyle.UPPER_CENTER);
                         IsEnabled = false;
-                    }
+                    } else if (antra_rate_d >= 0) { // no where to store it
+		      antra_rate_d = 0;
+		      consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+		    }
                 } else if (active_mode == 5) { // Monoprop Production
                     double density_h2o2 = PartResourceLibrary.Instance.GetDefinition(PluginHelper.hydrogen_peroxide_resource_name).density;
                     double density_h2o = PartResourceLibrary.Instance.GetDefinition(PluginHelper.water_resource_name).density;
@@ -315,8 +345,12 @@ namespace FNPlugin {
                         double mono_prop_produciton_rate = ammonia_consumption_rate + h202_consumption_rate;
                         double density_monoprop = PartResourceLibrary.Instance.GetDefinition("MonoPropellant").density;
                         monoprop_rate_d = -ORSHelper.fixedRequestResource(part,"MonoPropellant", -mono_prop_produciton_rate * TimeWarp.fixedDeltaTime / density_monoprop)*density_monoprop/TimeWarp.fixedDeltaTime;
-                        ORSHelper.fixedRequestResource(part, PluginHelper.water_resource_name, -mono_prop_produciton_rate * TimeWarp.fixedDeltaTime * 1.12436683185 / density_h2o);
-                    } else {
+			if (monoprop_rate_d >= 0) { //no where to store it
+			  consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+			} else {
+			  ORSHelper.fixedRequestResource(part, PluginHelper.water_resource_name, -mono_prop_produciton_rate * TimeWarp.fixedDeltaTime * 1.12436683185 / density_h2o);
+			}
+                    } else { // none to consume
                         if (electrical_power_ratio > 0) {
                             monoprop_rate_d = 0;
                             ScreenMessages.PostScreenMessage("Ammonia and Hydrogen Peroxide are required to produce Monopropellant.", 5.0f, ScreenMessageStyle.UPPER_CENTER);
@@ -337,7 +371,10 @@ namespace FNPlugin {
                     double ammonia_rate = ORSHelper.fixedRequestResource(part, PluginHelper.ammonia_resource_name, uf4persec * TimeWarp.fixedDeltaTime);
                     if (uf4_rate > 0 && ammonia_rate > 0) {
                         uranium_nitride_rate_d = -ORSHelper.fixedRequestResource(part, "UraniumNitride", -uf4_rate * density_uf4 / 1.24597 / density_un)/TimeWarp.fixedDeltaTime*density_un;
-                    } else {
+			if (uranium_nitride_rate_d >= 0) { // no where to store it
+			  consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+			}
+                    } else { // none to convert
                         if (electrical_power_ratio > 0) {
                             uranium_nitride_rate_d = 0;
                             ScreenMessages.PostScreenMessage("Uranium Tetraflouride and Ammonia are required to produce Uranium Nitride.", 5.0f, ScreenMessageStyle.UPPER_CENTER);
@@ -355,7 +392,10 @@ namespace FNPlugin {
                         double ammonia_rate_to_add_t = ORSHelper.fixedRequestResource(part, PluginHelper.hydrogen_resource_name, hydrogen_rate_t * TimeWarp.fixedDeltaTime / density_h) * density_h / GameConstants.ammoniaHydrogenFractionByMass/TimeWarp.fixedDeltaTime;
                         if (ammonia_rate_to_add_t > 0) {
                             ammonia_rate_d = -ORSHelper.fixedRequestResource(part, PluginHelper.ammonia_resource_name, -ammonia_rate_to_add_t * TimeWarp.fixedDeltaTime / density_ammonia) * density_ammonia/TimeWarp.fixedDeltaTime;
-                        } else {
+			    if (ammonia_rate_d >= 0) { // no where to store it
+			      consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+			    }
+                        } else { // none to convert
                             if (electrical_power_ratio > 0) {
                                 ScreenMessages.PostScreenMessage("Hydrogen is required to perform the Haber Process.", 5.0f, ScreenMessageStyle.UPPER_CENTER);
                                 IsEnabled = false;

--- a/OpenResourceSystem/ORSModuleResourceExtraction.cs
+++ b/OpenResourceSystem/ORSModuleResourceExtraction.cs
@@ -142,6 +142,13 @@ namespace OpenResourceSystem {
                     double resource_density = PartResourceLibrary.Instance.GetDefinition(resourceName).density;
                     //extraction_rate_d = -part.RequestResource(resourceName, -extraction_rate / resource_density * TimeWarp.fixedDeltaTime) / TimeWarp.fixedDeltaTime;
                     extraction_rate_d = -ORSHelper.fixedRequestResource(part,resourceName, -extraction_rate / resource_density * TimeWarp.fixedDeltaTime) / TimeWarp.fixedDeltaTime;
+		    if (extraction_rate_d >= 0) {
+		      if (resourceManaged) {
+			consumeFNResource(-electrical_power_provided, resourceToUse);
+		      } else {
+		        part.RequestResource(resourceToUse, -electrical_power_provided);
+		      }
+		    }
                 } else {
                     IsEnabled = false;
                 }


### PR DESCRIPTION
When mining and refining resources, Megajoules should only be consumed when there are input materials available AND there's storage onboard for the output materials.

This patch prevents a deadlock refueling condition. For example, on mun, a 1.25m generator + sethanes fission reactor cannot supply enough power to both mine alumina and electrolyse it into aluminum and oxidizer. If both options are enabled on the ISRU, the mining will take precidence and starve the electrolysis process of megajoules even when the alumina storage on the ship is full. With this patch applied, the mining function will stop consuming megajoules when there is no more room to store the alumina, so there will be power for the electrolysis to consume the alumina. This allows the ship to be refueled without requiring the player to constantly turn on and off the alumina mining option (although it will still be slower than if sufficient power generation were available).
