### PR TITLE
Development

### DIFF
--- a/FNPlugin/FNRefinery.cs
+++ b/FNPlugin/FNRefinery.cs
@@ -7,9 +7,11 @@ using System.Text;
 using UnityEngine;
 using ORSv1_1::OpenResourceSystem;
 
-namespace FNPlugin {
+namespace FNPlugin
+{
     [KSPModule("Refinery")]
-    class FNRefinery : FNResourceSuppliableModule {
+    class FNRefinery : FNResourceSuppliableModule
+    {
         //Persistent True
         [KSPField(isPersistant = true)]
         public bool IsEnabled = false;
@@ -55,11 +57,12 @@ namespace FNPlugin {
         protected double ammonia_rate_d = 0;
         protected bool play_down = true;
         protected Animation anim;
-        protected String[] modes = { "Nuclear Reprocessing", "Aluminium Electrolysis","Sabatier ISRU","Water Electrolysis","Anthraquinone Process","Monopropellant Production","UF4 Ammonolysis","Haber Process"};
+        protected String[] modes = { "Nuclear Reprocessing", "Aluminium Electrolysis", "Sabatier ISRU", "Water Electrolysis", "Anthraquinone Process", "Monopropellant Production", "UF4 Ammonolysis", "Haber Process" };
         protected FuelReprocessor reprocessor;
 
         [KSPEvent(guiActive = true, guiName = "Reprocess Nuclear Fuel", active = true)]
-        public void ReprocessFuel() {
+        public void ReprocessFuel()
+        {
             IsEnabled = true;
             play_down = true;
             active_mode = 0;
@@ -67,7 +70,8 @@ namespace FNPlugin {
         }
 
         [KSPEvent(guiActive = true, guiName = "Electrolyse Aluminium", active = true)]
-        public void ActivateElectrolysis() {
+        public void ActivateElectrolysis()
+        {
             IsEnabled = true;
             play_down = true;
             active_mode = 1;
@@ -75,7 +79,8 @@ namespace FNPlugin {
         }
 
         [KSPEvent(guiActive = true, guiName = "Begin Sabatier ISRU", active = true)]
-        public void ActivateSabatier() {
+        public void ActivateSabatier()
+        {
             IsEnabled = true;
             play_down = true;
             active_mode = 2;
@@ -83,7 +88,8 @@ namespace FNPlugin {
         }
 
         [KSPEvent(guiActive = true, guiName = "Electrolyse Water", active = true)]
-        public void ElectrolyseWater() {
+        public void ElectrolyseWater()
+        {
             IsEnabled = true;
             play_down = true;
             active_mode = 3;
@@ -91,7 +97,8 @@ namespace FNPlugin {
         }
 
         [KSPEvent(guiActive = true, guiName = "Anthraquinone Process", active = true)]
-        public void AnthraquinoneProcess() {
+        public void AnthraquinoneProcess()
+        {
             IsEnabled = true;
             play_down = true;
             active_mode = 4;
@@ -99,7 +106,8 @@ namespace FNPlugin {
         }
 
         [KSPEvent(guiActive = true, guiName = "Produce Monopropellant", active = true)]
-        public void ProduceMonoprop() {
+        public void ProduceMonoprop()
+        {
             IsEnabled = true;
             play_down = true;
             active_mode = 5;
@@ -107,7 +115,8 @@ namespace FNPlugin {
         }
 
         [KSPEvent(guiActive = true, guiName = "UF4 Ammonolysis", active = true)]
-        public void UraniumAmmonolysis() {
+        public void UraniumAmmonolysis()
+        {
             IsEnabled = true;
             play_down = true;
             active_mode = 6;
@@ -115,7 +124,8 @@ namespace FNPlugin {
         }
 
         [KSPEvent(guiActive = true, guiName = "Haber Process", active = true)]
-        public void HaberProcess() {
+        public void HaberProcess()
+        {
             IsEnabled = true;
             play_down = true;
             active_mode = 7;
@@ -123,27 +133,35 @@ namespace FNPlugin {
         }
 
         [KSPEvent(guiActive = true, guiName = "Stop Current Activity", active = false)]
-        public void StopActivity() {
+        public void StopActivity()
+        {
             IsEnabled = false;
         }
 
-        public override void OnStart(PartModule.StartState state) {
+        public override void OnStart(PartModule.StartState state)
+        {
             if (state == StartState.Editor) { return; }
             part.force_activate();
             reprocessor = new FuelReprocessor(part);
 
-            if (part.airlock != null && part.airlock.transform != null) {
-                if (part.airlock.transform.gameObject != null) {
+            if (part.airlock != null && part.airlock.transform != null)
+            {
+                if (part.airlock.transform.gameObject != null)
+                {
                     Destroy(part.airlock.transform.gameObject);
                 }
             }
 
             anim = part.FindModelAnimators(animName).FirstOrDefault();
-            if (anim != null) {
+            if (anim != null)
+            {
                 anim[animName].layer = 1;
-                if (IsEnabled) {
+                if (IsEnabled)
+                {
                     anim.Blend(animName, 2, 0);
-                } else {
+                }
+                else
+                {
                     play_down = false;
                     anim[animName].speed = -1f;
                     anim[animName].normalizedTime = 0f;
@@ -152,7 +170,8 @@ namespace FNPlugin {
             }
         }
 
-        public override void OnUpdate() {
+        public override void OnUpdate()
+        {
             Events["ReprocessFuel"].active = !IsEnabled;
             Events["ActivateElectrolysis"].active = !IsEnabled;
             Events["ActivateSabatier"].active = !IsEnabled;
@@ -171,81 +190,108 @@ namespace FNPlugin {
             Fields["ammoniaRate"].guiActive = false;
             Fields["powerStr"].guiActive = false;
 
-            if (IsEnabled) {
+            if (IsEnabled)
+            {
                 Events["StopActivity"].guiName = "Stop " + modes[active_mode];
                 Fields["powerStr"].guiActive = true;
                 statusTitle = modes[active_mode] + "...";
-                if (active_mode == 0) { // Fuel Reprocessing
+                if (active_mode == 0)
+                { // Fuel Reprocessing
                     double currentpowertmp = electrical_power_ratio * GameConstants.basePowerConsumption;
                     Fields["reprocessingRate"].guiActive = true;
                     reprocessingRate = reprocessing_rate_d.ToString("0.0") + " Hours Remaining";
                     powerStr = currentpowertmp.ToString("0.00") + "MW / " + GameConstants.basePowerConsumption.ToString("0.00") + "MW";
-                } else if (active_mode == 1) { // Electrolysis
+                }
+                else if (active_mode == 1)
+                { // Electrolysis
                     Fields["electrolysisRate"].guiActive = true;
                     double currentpowertmp = electrical_power_ratio * GameConstants.baseELCPowerConsumption;
                     double electrolysisratetmp = -electrolysis_rate_d * 86400;
                     electrolysisRate = electrolysisratetmp.ToString("0.0") + " mT/day";
                     powerStr = currentpowertmp.ToString("0.00") + "MW / " + GameConstants.baseELCPowerConsumption.ToString("0.00") + "MW";
-                } else if (active_mode == 2) { // Sabatier ISRU
+                }
+                else if (active_mode == 2)
+                { // Sabatier ISRU
                     Fields["sabatierRate"].guiActive = true;
                     double currentpowertmp = electrical_power_ratio * GameConstants.baseELCPowerConsumption;
                     powerStr = currentpowertmp.ToString("0.00") + "MW / " + GameConstants.baseELCPowerConsumption.ToString("0.00") + "MW";
                     sabatierRate = "CH4 " + (methane_rate_d * 86400).ToString("0.00") + " mT/day";
-                } else if (active_mode == 3) { // Water Electrolysis
+                }
+                else if (active_mode == 3)
+                { // Water Electrolysis
                     Fields["electrolysisRate"].guiActive = true;
                     double currentpowertmp = electrical_power_ratio * GameConstants.baseELCPowerConsumption;
                     double electrolysisratetmp = -electrolysis_rate_d * 86400;
                     electrolysisRate = electrolysisratetmp.ToString("0.0") + " mT/day";
                     powerStr = currentpowertmp.ToString("0.00") + "MW / " + GameConstants.baseELCPowerConsumption.ToString("0.00") + "MW";
-                } else if (active_mode == 4) { // Anthraquinone Process
+                }
+                else if (active_mode == 4)
+                { // Anthraquinone Process
                     Fields["anthraquinoneRate"].guiActive = true;
                     double currentpowertmp = electrical_power_ratio * GameConstants.baseAnthraquiononePowerConsumption;
                     double anthraratetmp = anthra_rate_d * 3600;
                     anthraquinoneRate = anthraratetmp.ToString("0.0") + " mT/hour";
                     powerStr = currentpowertmp.ToString("0.00") + "MW / " + GameConstants.baseAnthraquiononePowerConsumption.ToString("0.00") + "MW";
-                } else if (active_mode == 5) { // Produce MonoProp
+                }
+                else if (active_mode == 5)
+                { // Produce MonoProp
                     Fields["monopropellantRate"].guiActive = true;
                     double currentpowertmp = electrical_power_ratio * GameConstants.basePechineyUgineKuhlmannPowerConsumption;
                     double monoratetmp = monoprop_rate_d * 3600;
                     monopropellantRate = monoratetmp.ToString("0.0") + " mT/hour";
                     powerStr = currentpowertmp.ToString("0.00") + "MW / " + GameConstants.basePechineyUgineKuhlmannPowerConsumption.ToString("0.00") + "MW";
-                } else if (active_mode == 6) { // Uranium Ammonolysis
+                }
+                else if (active_mode == 6)
+                { // Uranium Ammonolysis
                     Fields["uraniumNitrideRate"].guiActive = true;
                     double currentpowertmp = electrical_power_ratio * GameConstants.baseUraniumAmmonolysisConsumption;
                     double uraniumnitrideratetmp = uranium_nitride_rate_d * 3600;
                     uraniumNitrideRate = uraniumnitrideratetmp.ToString("0.0") + " mT/hour";
                     powerStr = currentpowertmp.ToString("0.00") + "MW / " + GameConstants.baseUraniumAmmonolysisConsumption.ToString("0.00") + "MW";
-                } else if (active_mode == 7) { // Haber Process
+                }
+                else if (active_mode == 7)
+                { // Haber Process
                     Fields["ammoniaRate"].guiActive = true;
                     double currentpowertmp = electrical_power_ratio * GameConstants.baseHaberProcessPowerConsumption;
                     double ammoniaratetmp = ammonia_rate_d * 3600;
                     ammoniaRate = ammoniaratetmp.ToString("0.00") + " mT/hour";
                     powerStr = currentpowertmp.ToString("0.00") + "MW / " + GameConstants.baseHaberProcessPowerConsumption.ToString("0.00") + "MW";
                 }
-            } else {
-                if (play_down && anim != null) {
+            }
+            else
+            {
+                if (play_down && anim != null)
+                {
                     anim[animName].speed = -1f;
                     anim[animName].normalizedTime = 0f;
-                    anim.Blend(animName,0,1);
+                    anim.Blend(animName, 0, 1);
                     play_down = false;
                 }
                 statusTitle = "Offline";
             }
         }
 
-        public override void OnFixedUpdate() {
-            if (IsEnabled) {
-                if (active_mode == 0) { // Fuel Reprocessing
+        public override void OnFixedUpdate()
+        {
+            if (IsEnabled)
+            {
+                if (active_mode == 0)
+                { // Fuel Reprocessing
                     double electrical_power_provided = consumeFNResource(GameConstants.basePowerConsumption * TimeWarp.fixedDeltaTime, FNResourceManager.FNRESOURCE_MEGAJOULES);
                     electrical_power_ratio = (float)(electrical_power_provided / TimeWarp.fixedDeltaTime / GameConstants.basePowerConsumption);
                     reprocessor.performReprocessingFrame(electrical_power_ratio);
-                    if (reprocessor.getActinidesRemovedPerHour() > 0) {
+                    if (reprocessor.getActinidesRemovedPerHour() > 0)
+                    {
                         reprocessing_rate_d = reprocessor.getRemainingAmountToReprocess() / reprocessor.getActinidesRemovedPerHour();
-                    } else {
+                    }
+                    else
+                    {
                         ScreenMessages.PostScreenMessage("Unable to Reprocess Nuclear Fuel", 5.0f, ScreenMessageStyle.UPPER_CENTER);
                         IsEnabled = false;
-                    }                    
-                } else if (active_mode == 1) { // Aluminium Electrolysis
+                    }
+                }
+                else if (active_mode == 1)
+                { // Aluminium Electrolysis
                     double electrical_power_provided = consumeFNResource((GameConstants.baseELCPowerConsumption) * TimeWarp.fixedDeltaTime, FNResourceManager.FNRESOURCE_MEGAJOULES);
                     electrical_power_ratio = (float)(electrical_power_provided / TimeWarp.fixedDeltaTime / GameConstants.baseELCPowerConsumption);
                     double density_alumina = PartResourceLibrary.Instance.GetDefinition("Alumina").density;
@@ -253,76 +299,93 @@ namespace FNPlugin {
                     double oxygen_density = PartResourceLibrary.Instance.GetDefinition(PluginHelper.oxygen_resource_name).density;
                     electrolysis_rate_d = electrical_power_provided / GameConstants.aluminiumElectrolysisEnergyPerTon / TimeWarp.fixedDeltaTime;
                     double alumina_consumption_rate = part.RequestResource("Alumina", electrolysis_rate_d * TimeWarp.fixedDeltaTime / density_alumina) / TimeWarp.fixedDeltaTime * density_alumina;
-		    double mass_rate = alumina_consumption_rate;
-		    electrolysis_rate_d = part.RequestResource(PluginHelper.aluminium_resource_name, -mass_rate * TimeWarp.fixedDeltaTime / aluminium_density) * aluminium_density;
-		    electrolysis_rate_d += part.RequestResource(PluginHelper.oxygen_resource_name, -GameConstants.aluminiumElectrolysisMassRatio * mass_rate * TimeWarp.fixedDeltaTime / oxygen_density) * oxygen_density;
-		    electrolysis_rate_d = electrolysis_rate_d / TimeWarp.fixedDeltaTime;
-		    if (electrolysis_rate_d <= 0) { //no where to store it
-		      part.RequestResource("Alumina", -alumina_consumption_rate * TimeWarp.fixedDeltaTime / density_alumina); 
-		      consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
-		      electrolysis_rate_d = electrical_power_ratio = 0;
-		    }
-                } else if (active_mode == 2) { // Sabatier ISRU
-                    if (FlightGlobals.getStaticPressure(vessel.transform.position) * ORSAtmosphericResourceHandler.getAtmosphericResourceContentByDisplayName(vessel.mainBody.flightGlobalsIndex, "Carbon Dioxide") >= 0.01) {
+                    double mass_rate = alumina_consumption_rate;
+                    electrolysis_rate_d = part.RequestResource(PluginHelper.aluminium_resource_name, -mass_rate * TimeWarp.fixedDeltaTime / aluminium_density) * aluminium_density;
+                    electrolysis_rate_d += part.RequestResource(PluginHelper.oxygen_resource_name, -GameConstants.aluminiumElectrolysisMassRatio * mass_rate * TimeWarp.fixedDeltaTime / oxygen_density) * oxygen_density;
+                    electrolysis_rate_d = electrolysis_rate_d / TimeWarp.fixedDeltaTime;
+                    if (electrolysis_rate_d >= 0)
+                    { //no where to store it
+                        part.RequestResource("Alumina", -alumina_consumption_rate * TimeWarp.fixedDeltaTime / density_alumina);
+                        supplyFNResource(electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+                        electrolysis_rate_d = electrical_power_ratio = 0;
+                    }
+                }
+                else if (active_mode == 2)
+                { // Sabatier ISRU
+                    if (FlightGlobals.getStaticPressure(vessel.transform.position) * ORSAtmosphericResourceHandler.getAtmosphericResourceContentByDisplayName(vessel.mainBody.flightGlobalsIndex, "Carbon Dioxide") >= 0.01)
+                    {
                         double electrical_power_provided = consumeFNResource((GameConstants.baseELCPowerConsumption) * TimeWarp.fixedDeltaTime, FNResourceManager.FNRESOURCE_MEGAJOULES);
                         electrical_power_ratio = (float)(electrical_power_provided / TimeWarp.fixedDeltaTime / GameConstants.baseELCPowerConsumption);
                         electrolysis_rate_d = electrical_power_provided / GameConstants.electrolysisEnergyPerTon * vessel.atmDensity / TimeWarp.fixedDeltaTime;
                         double hydrogen_rate = electrolysis_rate_d / (1 + GameConstants.electrolysisMassRatio);
-                        double oxygen_rate = hydrogen_rate * (GameConstants.electrolysisMassRatio-1);
+                        double oxygen_rate = hydrogen_rate * (GameConstants.electrolysisMassRatio - 1);
                         double density_h = PartResourceLibrary.Instance.GetDefinition(PluginHelper.hydrogen_resource_name).density;
                         double density_o = PartResourceLibrary.Instance.GetDefinition(PluginHelper.oxygen_resource_name).density;
                         double density_ch4 = PartResourceLibrary.Instance.GetDefinition(PluginHelper.methane_resource_name).density;
                         double h2_rate = part.RequestResource(PluginHelper.hydrogen_resource_name, hydrogen_rate * TimeWarp.fixedDeltaTime / density_h / 2);
-			double o_rate = part.RequestResource(PluginHelper.oxygen_resource_name, -oxygen_rate * TimeWarp.fixedDeltaTime / density_o);
-			double methane_rate = oxygen_rate * 2;
-			methane_rate_d = -part.RequestResource(PluginHelper.methane_resource_name, -methane_rate * TimeWarp.fixedDeltaTime / density_ch4) * density_ch4 / TimeWarp.fixedDeltaTime;
-			if (methane_rate_d <= 0) { //no where to store it
-			  part.RequestResource(PluginHelper.hydrogen_resource_name, -h2_rate);
-			  part.RequestResource(PluginHelper.oxygen_resource_name, -o_rate);
-			  consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
-			  electrical_power_ratio = electrolysis_rate_d = methane_rate_d = 0;
-			}
-                    } else {
+                        double o_rate = part.RequestResource(PluginHelper.oxygen_resource_name, -oxygen_rate * TimeWarp.fixedDeltaTime / density_o);
+                        double methane_rate = oxygen_rate * 2;
+                        methane_rate_d = -part.RequestResource(PluginHelper.methane_resource_name, -methane_rate * TimeWarp.fixedDeltaTime / density_ch4) * density_ch4 / TimeWarp.fixedDeltaTime;
+                        if (methane_rate_d <= 0)
+                        { //no where to store it
+                            part.RequestResource(PluginHelper.hydrogen_resource_name, -h2_rate);
+                            part.RequestResource(PluginHelper.oxygen_resource_name, -o_rate);
+                            supplyFNResource(electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+                            electrolysis_rate_d = methane_rate_d = electrical_power_ratio = 0;
+                        }
+                    }
+                    else
+                    {
                         ScreenMessages.PostScreenMessage("Ambient C02 insufficient.", 5.0f, ScreenMessageStyle.UPPER_CENTER);
                         IsEnabled = false;
                     }
-                } else if (active_mode == 3) { // Water Electrolysis
+                }
+                else if (active_mode == 3)
+                { // Water Electrolysis
                     double density_h = PartResourceLibrary.Instance.GetDefinition(PluginHelper.hydrogen_resource_name).density;
                     double density_o = PartResourceLibrary.Instance.GetDefinition(PluginHelper.oxygen_resource_name).density;
                     double density_h2o = PartResourceLibrary.Instance.GetDefinition(PluginHelper.water_resource_name).density;
                     double electrical_power_provided = consumeFNResource((GameConstants.baseELCPowerConsumption) * TimeWarp.fixedDeltaTime, FNResourceManager.FNRESOURCE_MEGAJOULES);
                     electrical_power_ratio = (float)(electrical_power_provided / TimeWarp.fixedDeltaTime / GameConstants.baseELCPowerConsumption);
                     electrolysis_rate_d = electrical_power_provided / GameConstants.electrolysisEnergyPerTon / TimeWarp.fixedDeltaTime;
-                    double water_consumption_rate = part.RequestResource(PluginHelper.water_resource_name, electrolysis_rate_d * TimeWarp.fixedDeltaTime / density_h2o) / TimeWarp.fixedDeltaTime*density_h2o;
-		    double hydrogen_rate = water_consumption_rate / (1 + GameConstants.electrolysisMassRatio);
-		    double oxygen_rate = hydrogen_rate * GameConstants.electrolysisMassRatio;
-		    double h_rate = part.RequestResource(PluginHelper.hydrogen_resource_name, -hydrogen_rate * TimeWarp.fixedDeltaTime / density_h);
-		    double o_rate = part.RequestResource(PluginHelper.oxygen_resource_name, -oxygen_rate * TimeWarp.fixedDeltaTime / density_o);
-		    electrolysis_rate_d = (h_rate + o_rate) / TimeWarp.fixedDeltaTime * density_h;
-		    if (electrolysis_rate_d <= 0) { // no where to store it
-		      part.RequestResource(PluginHelper.water_resource_name, -water_consumption_rate * TimeWarp.fixedDeltaTime / density_h2o);
-		      part.RequestResource(PluginHelper.hydrogen_resource_name, -h_rate);
-		      part.RequestResource(PluginHelper.oxygen_resource_name, -o_rate);
-		      consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
-		      electrolysis_rate_d = electrical_power_ratio = 0;
-		    }
-                } else if (active_mode == 4) { // Anthraquinone Process
+                    double water_consumption_rate = part.RequestResource(PluginHelper.water_resource_name, electrolysis_rate_d * TimeWarp.fixedDeltaTime / density_h2o) / TimeWarp.fixedDeltaTime * density_h2o;
+                    double hydrogen_rate = water_consumption_rate / (1 + GameConstants.electrolysisMassRatio);
+                    double oxygen_rate = hydrogen_rate * GameConstants.electrolysisMassRatio;
+                    double h_rate = part.RequestResource(PluginHelper.hydrogen_resource_name, -hydrogen_rate * TimeWarp.fixedDeltaTime / density_h);
+                    double o_rate = part.RequestResource(PluginHelper.oxygen_resource_name, -oxygen_rate * TimeWarp.fixedDeltaTime / density_o);
+                    electrolysis_rate_d = (h_rate + o_rate) / TimeWarp.fixedDeltaTime * density_h;
+                    if (electrolysis_rate_d >= 0)
+                    { // no where to store it
+                        part.RequestResource(PluginHelper.water_resource_name, -water_consumption_rate * TimeWarp.fixedDeltaTime / density_h2o);
+                        part.RequestResource(PluginHelper.hydrogen_resource_name, -h_rate);
+                        part.RequestResource(PluginHelper.oxygen_resource_name, -o_rate);
+                        supplyFNResource(electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+                        electrolysis_rate_d = electrical_power_ratio = 0;
+                    }
+                }
+                else if (active_mode == 4)
+                { // Anthraquinone Process
                     double density_h2o = PartResourceLibrary.Instance.GetDefinition(PluginHelper.water_resource_name).density;
                     double density_h2o2 = PartResourceLibrary.Instance.GetDefinition(PluginHelper.hydrogen_peroxide_resource_name).density;
                     double electrical_power_provided = consumeFNResource((GameConstants.baseAnthraquiononePowerConsumption) * TimeWarp.fixedDeltaTime, FNResourceManager.FNRESOURCE_MEGAJOULES);
                     electrical_power_ratio = (float)(electrical_power_provided / TimeWarp.fixedDeltaTime / GameConstants.baseAnthraquiononePowerConsumption);
                     anthra_rate_d = electrical_power_provided / GameConstants.anthraquinoneEnergyPerTon / TimeWarp.fixedDeltaTime;
                     double water_consumption_rate = part.RequestResource(PluginHelper.water_resource_name, anthra_rate_d * TimeWarp.fixedDeltaTime / density_h2o) / TimeWarp.fixedDeltaTime * density_h2o;
-                    anthra_rate_d = -part.RequestResource(PluginHelper.hydrogen_peroxide_resource_name, -water_consumption_rate * TimeWarp.fixedDeltaTime / density_h2o2) * density_h2o2/TimeWarp.fixedDeltaTime;
-                    if (water_consumption_rate <= 0 && electrical_power_ratio > 0) {
+                    anthra_rate_d = -part.RequestResource(PluginHelper.hydrogen_peroxide_resource_name, -water_consumption_rate * TimeWarp.fixedDeltaTime / density_h2o2) * density_h2o2 / TimeWarp.fixedDeltaTime;
+                    if (water_consumption_rate <= 0 && electrical_power_ratio > 0)
+                    {
                         ScreenMessages.PostScreenMessage("Water is required to perform the Anthraquinone Process.", 5.0f, ScreenMessageStyle.UPPER_CENTER);
                         IsEnabled = false;
-                    } else if (anthra_rate_d <= 0) { // no where to store it
-		      part.RequestResource(PluginHelper.water_resource_name, -water_consumption_rate * TimeWarp.fixedDeltaTime / density_h2o);
-		      consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
-		      electrical_power_ratio = anthra_rate_d = 0;
-		    }
-                } else if (active_mode == 5) { // Monoprop Production
+                    }
+                    else if (anthra_rate_d <= 0)
+                    { // no where to store it
+                        part.RequestResource(PluginHelper.water_resource_name, -water_consumption_rate * TimeWarp.fixedDeltaTime / density_h2o);
+                        supplyFNResource(electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+                        anthra_rate_d = electrical_power_ratio = 0;
+                    }
+                }
+                else if (active_mode == 5)
+                { // Monoprop Production
                     double density_h2o2 = PartResourceLibrary.Instance.GetDefinition(PluginHelper.hydrogen_peroxide_resource_name).density;
                     double density_h2o = PartResourceLibrary.Instance.GetDefinition(PluginHelper.water_resource_name).density;
                     double density_ammonia = PartResourceLibrary.Instance.GetDefinition(PluginHelper.ammonia_resource_name).density;
@@ -331,29 +394,38 @@ namespace FNPlugin {
                     monoprop_rate_d = electrical_power_provided / GameConstants.pechineyUgineKuhlmannEnergyPerTon / TimeWarp.fixedDeltaTime;
                     double ammonia_consumption_rate = part.RequestResource(PluginHelper.ammonia_resource_name, 0.5 * monoprop_rate_d * (1 - GameConstants.pechineyUgineKuhlmannMassRatio) * TimeWarp.fixedDeltaTime / density_ammonia) * density_ammonia / TimeWarp.fixedDeltaTime;
                     double h202_consumption_rate = part.RequestResource(PluginHelper.hydrogen_peroxide_resource_name, 0.5 * monoprop_rate_d * GameConstants.pechineyUgineKuhlmannMassRatio * TimeWarp.fixedDeltaTime / density_h2o2) * density_h2o2 / TimeWarp.fixedDeltaTime;
-                    if (ammonia_consumption_rate > 0 && h202_consumption_rate > 0) {
+                    if (ammonia_consumption_rate > 0 && h202_consumption_rate > 0)
+                    {
                         double mono_prop_produciton_rate = ammonia_consumption_rate + h202_consumption_rate;
                         double density_monoprop = PartResourceLibrary.Instance.GetDefinition("MonoPropellant").density;
-                        monoprop_rate_d = -ORSHelper.fixedRequestResource(part,"MonoPropellant", -mono_prop_produciton_rate * TimeWarp.fixedDeltaTime / density_monoprop)*density_monoprop/TimeWarp.fixedDeltaTime;
-			if (monoprop_rate_d <= 0) { //no where to store it
-			  part.RequestResource(PluginHelper.ammonia_resource_name, -ammonia_consumption_rate * TimeWarp.fixedDeltaTime / density_ammonia);
-			  part.RequestResource(PluginHelper.hydrogen_peroxide_resource_name, -h202_consumption_rate * TimeWarp.fixedDeltaTime / density_ammonia);
-			  consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
-			  electrical_power_ratio = monoprop_rate_d = 0;
-			} else {
-			  ORSHelper.fixedRequestResource(part, PluginHelper.water_resource_name, -mono_prop_produciton_rate * TimeWarp.fixedDeltaTime * 1.12436683185 / density_h2o);
-			}
-                    } else { // none to consume
-                        if (electrical_power_ratio > 0) {
-			  part.RequestResource(PluginHelper.ammonia_resource_name, -ammonia_consumption_rate * TimeWarp.fixedDeltaTime / density_ammonia);
-			  part.RequestResource(PluginHelper.hydrogen_peroxide_resource_name, -h202_consumption_rate * TimeWarp.fixedDeltaTime / density_ammonia);
-			  consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
-			  electrical_power_ratio = monoprop_rate_d = 0;
+                        monoprop_rate_d = -ORSHelper.fixedRequestResource(part, "MonoPropellant", -mono_prop_produciton_rate * TimeWarp.fixedDeltaTime / density_monoprop) * density_monoprop / TimeWarp.fixedDeltaTime;
+                        if (monoprop_rate_d <= 0)
+                        { //no where to store it
+                            part.RequestResource(PluginHelper.ammonia_resource_name, -ammonia_consumption_rate * TimeWarp.fixedDeltaTime / density_ammonia);
+                            part.RequestResource(PluginHelper.hydrogen_peroxide_resource_name, -h202_consumption_rate * TimeWarp.fixedDeltaTime / density_ammonia);
+                            supplyFNResource(electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+                            monoprop_rate_d = electrical_power_ratio = 0;
+                        }
+                        else
+                        {
+                            ORSHelper.fixedRequestResource(part, PluginHelper.water_resource_name, -mono_prop_produciton_rate * TimeWarp.fixedDeltaTime * 1.12436683185 / density_h2o);
+                        }
+                    }
+                    else
+                    { // none to consume
+                        if (electrical_power_ratio > 0)
+                        {
+                            part.RequestResource(PluginHelper.ammonia_resource_name, -ammonia_consumption_rate * TimeWarp.fixedDeltaTime / density_ammonia);
+                            part.RequestResource(PluginHelper.hydrogen_peroxide_resource_name, -h202_consumption_rate * TimeWarp.fixedDeltaTime / density_ammonia);
+                            supplyFNResource(electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+                            monoprop_rate_d = electrical_power_ratio = 0;
                             ScreenMessages.PostScreenMessage("Ammonia and Hydrogen Peroxide are required to produce Monopropellant.", 5.0f, ScreenMessageStyle.UPPER_CENTER);
                             IsEnabled = false;
                         }
                     }
-                } else if (active_mode == 6) {
+                }
+                else if (active_mode == 6)
+                {
                     double density_ammonia = PartResourceLibrary.Instance.GetDefinition(PluginHelper.ammonia_resource_name).density;
                     double density_uf4 = PartResourceLibrary.Instance.GetDefinition("UF4").density;
                     double density_un = PartResourceLibrary.Instance.GetDefinition("UraniumNitride").density;
@@ -365,77 +437,100 @@ namespace FNPlugin {
                     double ammoniapersec = lpersec * 0.901 / density_ammonia;
                     double uf4_rate = ORSHelper.fixedRequestResource(part, "UF4", uf4persec * TimeWarp.fixedDeltaTime);
                     double ammonia_rate = ORSHelper.fixedRequestResource(part, PluginHelper.ammonia_resource_name, uf4persec * TimeWarp.fixedDeltaTime);
-                    if (uf4_rate > 0 && ammonia_rate > 0) {
-                        uranium_nitride_rate_d = -ORSHelper.fixedRequestResource(part, "UraniumNitride", -uf4_rate * density_uf4 / 1.24597 / density_un)/TimeWarp.fixedDeltaTime*density_un;
-			if (uranium_nitride_rate_d <= 0) { // no where to store it
-			  ORSHelper.fixedRequestResource(part, "UF4", -uf4_rate);
-			  ORSHelper.fixedRequestResource(part, PluginHelper.ammonia_resource_name, -ammonia_rate);
-			  consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
-			  electrical_power_ratio = uranium_nitride_rate_d = 0;
-			}
-                    } else { // none to convert
-                        if (electrical_power_ratio > 0) {
-			  ORSHelper.fixedRequestResource(part, "UF4", -uf4_rate);
-			  ORSHelper.fixedRequestResource(part, PluginHelper.ammonia_resource_name, -ammonia_rate);
-			  consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
-			  electrical_power_ratio = 0;
+                    if (uf4_rate > 0 && ammonia_rate > 0)
+                    {
+                        uranium_nitride_rate_d = -ORSHelper.fixedRequestResource(part, "UraniumNitride", -uf4_rate * density_uf4 / 1.24597 / density_un) / TimeWarp.fixedDeltaTime * density_un;
+                        if (uranium_nitride_rate_d <= 0)
+                        { // no where to store it
+                            ORSHelper.fixedRequestResource(part, "UF4", -uf4_rate);
+                            ORSHelper.fixedRequestResource(part, PluginHelper.ammonia_resource_name, -ammonia_rate);
+                            supplyFNResource(electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+                            uranium_nitride_rate_d = electrical_power_ratio = 0;
+                        }
+                    }
+                    else
+                    { // none to convert
+                        if (electrical_power_ratio > 0)
+                        {
+                            ORSHelper.fixedRequestResource(part, "UF4", -uf4_rate);
+                            ORSHelper.fixedRequestResource(part, PluginHelper.ammonia_resource_name, -ammonia_rate);
+                            supplyFNResource(electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+                            electrical_power_ratio = 0;
                             uranium_nitride_rate_d = 0;
                             ScreenMessages.PostScreenMessage("Uranium Tetraflouride and Ammonia are required to produce Uranium Nitride.", 5.0f, ScreenMessageStyle.UPPER_CENTER);
                             IsEnabled = false;
                         }
                     }
 
-                } else if (active_mode == 7) {
-                    if (FlightGlobals.getStaticPressure(vessel.transform.position) * ORSAtmosphericResourceHandler.getAtmosphericResourceContentByDisplayName(vessel.mainBody.flightGlobalsIndex, "Nitrogen") >= 0.1) {
+                }
+                else if (active_mode == 7)
+                {
+                    if (FlightGlobals.getStaticPressure(vessel.transform.position) * ORSAtmosphericResourceHandler.getAtmosphericResourceContentByDisplayName(vessel.mainBody.flightGlobalsIndex, "Nitrogen") >= 0.1)
+                    {
                         double density_ammonia = PartResourceLibrary.Instance.GetDefinition(PluginHelper.ammonia_resource_name).density;
                         double density_h = PartResourceLibrary.Instance.GetDefinition(PluginHelper.hydrogen_resource_name).density;
                         double electrical_power_provided = consumeFNResource((GameConstants.baseHaberProcessPowerConsumption) * TimeWarp.fixedDeltaTime, FNResourceManager.FNRESOURCE_MEGAJOULES);
                         electrical_power_ratio = (float)(electrical_power_provided / TimeWarp.fixedDeltaTime / GameConstants.baseHaberProcessPowerConsumption);
-                        double hydrogen_rate_t = electrical_power_provided / GameConstants.baseHaberProcessEnergyPerTon * GameConstants.ammoniaHydrogenFractionByMass/TimeWarp.fixedDeltaTime;
-                        double ammonia_rate_to_add_t = ORSHelper.fixedRequestResource(part, PluginHelper.hydrogen_resource_name, hydrogen_rate_t * TimeWarp.fixedDeltaTime / density_h) * density_h / GameConstants.ammoniaHydrogenFractionByMass/TimeWarp.fixedDeltaTime;
-                        if (ammonia_rate_to_add_t > 0) {
-                            ammonia_rate_d = -ORSHelper.fixedRequestResource(part, PluginHelper.ammonia_resource_name, -ammonia_rate_to_add_t * TimeWarp.fixedDeltaTime / density_ammonia) * density_ammonia/TimeWarp.fixedDeltaTime;
-			    if (ammonia_rate_d <= 0) { // no where to store it
-			      ORSHelper.fixedRequestResource(part, PluginHelper.hydrogen_resource_name, -ammonia_rate_to_add_t / density_h * GameConstants.ammoniaHydrogenFractionByMass * TimeWarp.fixedDelatTime);
-			      consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
-			      electrical_power_ratio = ammonia_rate_d = 0;
-			    }
-                        } else { // none to convert
-                            if (electrical_power_ratio > 0) {
-			      consumeFNResource(-electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
-			      electrical_power_ratio = ammonia_rate_d = 0;
+                        double hydrogen_rate_t = electrical_power_provided / GameConstants.baseHaberProcessEnergyPerTon * GameConstants.ammoniaHydrogenFractionByMass / TimeWarp.fixedDeltaTime;
+                        double ammonia_rate_to_add_t = ORSHelper.fixedRequestResource(part, PluginHelper.hydrogen_resource_name, hydrogen_rate_t * TimeWarp.fixedDeltaTime / density_h) * density_h / GameConstants.ammoniaHydrogenFractionByMass / TimeWarp.fixedDeltaTime;
+                        if (ammonia_rate_to_add_t > 0)
+                        {
+                            ammonia_rate_d = -ORSHelper.fixedRequestResource(part, PluginHelper.ammonia_resource_name, -ammonia_rate_to_add_t * TimeWarp.fixedDeltaTime / density_ammonia) * density_ammonia / TimeWarp.fixedDeltaTime;
+                            if (ammonia_rate_d <= 0)
+                            { // no where to store it
+                                ORSHelper.fixedRequestResource(part, PluginHelper.hydrogen_resource_name, -ammonia_rate_to_add_t / density_h * GameConstants.ammoniaHydrogenFractionByMass * TimeWarp.fixedDeltaTime);
+                                supplyFNResource(electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+                                ammonia_rate_d = electrical_power_ratio = 0;
+                            }
+                        }
+                        else
+                        { // none to convert
+                            if (electrical_power_ratio > 0)
+                            {
+                                supplyFNResource(electrical_power_provided, FNResourceManager.FNRESOURCE_MEGAJOULES);
+                                ammonia_rate_d = electrical_power_ratio = 0;
                                 ScreenMessages.PostScreenMessage("Hydrogen is required to perform the Haber Process.", 5.0f, ScreenMessageStyle.UPPER_CENTER);
                                 IsEnabled = false;
                             }
                         }
-                    } else {
+                    }
+                    else
+                    {
                         ScreenMessages.PostScreenMessage("Ambient Nitrogen Insufficient.", 5.0f, ScreenMessageStyle.UPPER_CENTER);
                         IsEnabled = false;
                     }
 
                 }
-            } else {
-                
+            }
+            else
+            {
+
             }
         }
 
-        public override string getResourceManagerDisplayName() {
-            if (IsEnabled) {
+        public override string getResourceManagerDisplayName()
+        {
+            if (IsEnabled)
+            {
                 return "ISRU Refinery (" + modes[active_mode] + ")";
             }
             return "ISRU Refinery";
         }
 
-        public override string GetInfo() {
+        public override string GetInfo()
+        {
             string infostr = "ISRU Refinery\nFunctions:\n";
-            foreach (string mode in modes) {
+            foreach (string mode in modes)
+            {
                 infostr += mode + "\n";
             }
             return infostr;
         }
 
-        protected void activateAnimation() {
-            if (anim != null) {
+        protected void activateAnimation()
+        {
+            if (anim != null)
+            {
                 anim[animName].speed = 1f;
                 anim[animName].normalizedTime = 0f;
                 anim.Blend(animName, 1, 1);


### PR DESCRIPTION
OK. Working Visual Studio means I could actually compile and test this before sending the pull request. You do not want to know what I had to do to get that build environment set up.

When mining using ORS, if there's insufficient storage for the output product, I refund the fraction of the power that wasn't used. I also made the power usage gui element smooth out a bit for situations where the miner is racing the refinery.

When refining using the ISRU, if no output material was able to be stored, I refund all of the source materials and megajoules. Gui elements in the context menu properly display power usage and conversion rates.

When both ORS mining AND ISRU refining are active and competing for insufficient power, mining seems to get priority until the resource is full, at which point it'll start refunding power. The ISRU then has some power left when its turn comes around, and removes some of the base resource to produce whatever. On the next tick, mining isn't full anymore, so it'll use a fraction of a tick of power to top off, leaving the ISRU with a fraction of the power for the tick to do a small amount of conversion. At this point it's steady state until the ISRU's output products are full, at which point they'll both stop using power with their tanks completely full, and megajoules will begin to accumulate again.

Thus, a ship with an ISRU and an aluminum hybrid rocket on mun, with an un-upgraded 6.25m fission reactor and generator, can now (eventually) refuel by leaving the mining and electrolysis options turned on at the same time.
