### PR TITLE
Power generation from mixed mode reactors/minor power transmission fix

### DIFF
--- a/InterstellarPlugin/FNGenerator.cs
+++ b/InterstellarPlugin/FNGenerator.cs
@@ -341,9 +341,6 @@ namespace InterstellarPlugin {
                     double thermal_power_currently_needed = electrical_power_currently_needed / totalEff;
                     double thermaldt = Math.Max(Math.Min(maxThermalPower, thermal_power_currently_needed) * TimeWarp.fixedDeltaTime, 0.0);
                     input_power = consumeFNResource(thermaldt, FNResourceManager.FNRESOURCE_THERMALPOWER);
-                    if (input_power < thermaldt) {
-                        input_power += consumeFNResource(thermaldt-input_power, FNResourceManager.FNRESOURCE_CHARGED_PARTICLES);
-                    }
                     double wastedt = input_power * totalEff;
                     consumeFNResource(wastedt, FNResourceManager.FNRESOURCE_WASTEHEAT);
                     electricdt = input_power * totalEff;
@@ -352,13 +349,13 @@ namespace InterstellarPlugin {
                 } else {
                     totalEff = 0.85;
                     double charged_power_currently_needed = electrical_power_currently_needed / totalEff;
-                    input_power = consumeFNResource(Math.Max(charged_power_currently_needed*TimeWarp.fixedDeltaTime,0), FNResourceManager.FNRESOURCE_CHARGED_PARTICLES);
+                    double chageddt = Math.Max(Math.Min(maxChargedPower, charged_power_currently_needed) * TimeWarp.fixedDeltaTime, 0.0);
+                    input_power = consumeFNResource(chageddt, FNResourceManager.FNRESOURCE_CHARGED_PARTICLES);
+                    double wastedt = input_power * totalEff;
+                    consumeFNResource(wastedt, FNResourceManager.FNRESOURCE_WASTEHEAT);
                     electricdt = input_power * totalEff;
                     electricdtps = Math.Max(electricdt / TimeWarp.fixedDeltaTime, 0.0);
-                    double wastedt = input_power * totalEff;
                     max_electricdtps = maxChargedPower * totalEff;
-                    consumeFNResource(wastedt, FNResourceManager.FNRESOURCE_WASTEHEAT);
-                    //supplyFNResource(wastedt, FNResourceManager.FNRESOURCE_WASTEHEAT);
                 }
 				outputPower = -(float)supplyFNResourceFixedMax (electricdtps * TimeWarp.fixedDeltaTime, max_electricdtps * TimeWarp.fixedDeltaTime, FNResourceManager.FNRESOURCE_MEGAJOULES) / TimeWarp.fixedDeltaTime;
 			} else {

--- a/InterstellarPlugin/FNReactor.cs
+++ b/InterstellarPlugin/FNReactor.cs
@@ -443,7 +443,7 @@ namespace InterstellarPlugin
 
         public float getThermalPower()
         {
-            return ThermalPower;
+            return ThermalPower * (1 - chargedParticleRatio);
         }
 
         public float getChargedPower()


### PR DESCRIPTION
**Fix Reactors reporting wrong Thermal Power value when in mixed mode** - when reactors are producing both Thermal Power and Charged Particles attached generators read wrong Thermal Power value from reactors as if reactor generated his full potential power as Thermal Power

**Fix Thermal Generators eating Charged Particles** - it is normal, that Thermal generators can use Charged Particles to generate power if Direct Conversion Generator is not present or disabled, that should not be the case, Thermal Generators should use only Thermal Power

**Fix Direct Conversion Generators being able to exceed their capabilities** - when there's more than one Direct Conversion Generator (as if with more than one Fusion Reactor in mixed mode for example) occasionally one of them can use all Charged Particles and exceed its maximum capacity without any drawbacks (same thing happens when one of generators is shut down)

**Fix Microwave Transceivers power reservation for Fusion Reactors** - switch from "magic numbers" to actual value - 0.95 is some number, what it means? where it came from? better solution is to use value provided by FNFusionReactor itself.

Let me know what you think about this.

Cheers,
_Signed-off-by: Tomasz Majer tomkuzyno@gmail.com_
