### PR TITLE
Another take on MicrowavePowerTransmitter

### DIFF
--- a/OpenResourceSystem/ORSResourceManager.cs
+++ b/OpenResourceSystem/ORSResourceManager.cs
@@ -8,6 +8,8 @@ namespace OpenResourceSystem
 {
     public class ORSResourceManager
     {
+        public List<KeyValuePair<ORSResourceSuppliable, double>> PowerDraws
+        { get { return power_draw_list_archive; } }
         public const string FNRESOURCE_MEGAJOULES = "Megajoules";
         public const string FNRESOURCE_CHARGED_PARTICLES = "ChargedParticles";
         public const string FNRESOURCE_THERMALPOWER = "ThermalPower";


### PR DESCRIPTION
Switched MicrowavePowerTransmitter power reservation from **FNFusionReactor.powerRequirements** to **ORSResourceManager.PowerDraws** (new read-only property exposing internal power_draw_list_archive).

Disallowed activating more than one MicrowavePowerTransmitter in transmitter mode (more than one relay is still allowed) as that causes trouble with power balancing between them, with two transmitters they will eventually reach equilibrium but any external change in power draw (eg. activating Science Lab) will throw them off balance, switching one transmitter on and off is required to regain balance, with more than two balance was never reached, and since having more than one transmitter shouldn't increase vessel's beamed power output and transmitter's size and orientation has no meaning for its performance, allowing more transmitters doesn't really have any sense.

Tested with:
- 2 Fusion Reactors, 4 Generators, 1 Science Lab switching Antimatter production on/off, 1 Computer Core, 1 Transmitter, ended up with positive power supply of 0.3 KW
- 2 Fusion Reactors, 4 Generators, 1 Science Lab switching Antimatter production on/off, 1 Computer Core, 2 Transmitters (reached equilibrium after ~3 sec. with positive power supply of 0.3 KW, required toggling of one transmitter every time Science Lab was switched on or off)
- 2 Fusion Reactors, 4 Generators, 1 Science Lab, 1 Computer Core, 4 Transmitters (after enabling 3rd transmitter equilibrium was never reached, that's why I disabled more than one transmitter)

_Signed-off-by: Tomasz Majer tomkuzyno@gmail.com_
