### PR TITLE
ORS Resource Fixes

### DIFF
--- a/OpenResourceSystem/ORSPlanetaryResourceMapData.cs
+++ b/OpenResourceSystem/ORSPlanetaryResourceMapData.cs
@@ -44,10 +44,20 @@ namespace OpenResourceSystem {
 					string resource_gui_name = planetary_resource_config_node.GetValue("name");
 					if (body_resource_maps.ContainsKey(resource_gui_name))
 						continue;
-                    Texture2D map = GameDatabase.Instance.GetTexture(planetary_resource_config_node.GetValue("mapUrl"), false);
-                    if (map == null) {
-                        continue;
-                    }
+					Texture2D map = GameDatabase.Instance.GetTexture(planetary_resource_config_node.GetValue("mapUrl"), false);
+					try
+					{
+						map.GetPixel(1, 1);
+					}
+					catch (UnityException e)
+					{
+						Debug.Log("Stop Doing Dumb Things With Your Map Textures: " + e);
+						continue;
+					}
+					if (map == null)
+					{
+						continue;
+					}
                     ORSPlanetaryResourceInfo resource_info = new ORSPlanetaryResourceInfo(resource_gui_name, map, body);
                     if (planetary_resource_config_node.HasValue("resourceName")) {
                         string resource_name = planetary_resource_config_node.GetValue("resourceName");

--- a/OpenResourceSystem/ORSPlanetaryResourceMapData.cs
+++ b/OpenResourceSystem/ORSPlanetaryResourceMapData.cs
@@ -41,11 +41,13 @@ namespace OpenResourceSystem {
                 ConfigNode planetary_resource_config_node = config.config;
                 if (planetary_resource_config_node.GetValue("celestialBodyName") == celestial_body_name && planetary_resource_config_node != null) {
                     Debug.Log("[ORS] Loading Planetary Resource Data for " + celestial_body_name);
+					string resource_gui_name = planetary_resource_config_node.GetValue("name");
+					if (body_resource_maps.ContainsKey(resource_gui_name))
+						continue;
                     Texture2D map = GameDatabase.Instance.GetTexture(planetary_resource_config_node.GetValue("mapUrl"), false);
                     if (map == null) {
                         continue;
                     }
-                    string resource_gui_name = planetary_resource_config_node.GetValue("name");
                     ORSPlanetaryResourceInfo resource_info = new ORSPlanetaryResourceInfo(resource_gui_name, map, body);
                     if (planetary_resource_config_node.HasValue("resourceName")) {
                         string resource_name = planetary_resource_config_node.GetValue("resourceName");
@@ -69,7 +71,7 @@ namespace OpenResourceSystem {
                         string tex_path = planetary_resource_config_node.GetValue("displayTexture");
                         resource_info.setDisplayTexture(tex_path);
                     } else {
-                        string tex_path = planetary_resource_config_node.GetValue("Interstellar/resource_point");
+                        string tex_path = planetary_resource_config_node.GetValue("WarpPlugin/resource_point");
                         resource_info.setDisplayTexture(tex_path);
                     }
                     if (planetary_resource_config_node.HasValue("displayThreshold")) {

--- a/OpenResourceSystem/ORSPlanetaryResourceMapData.cs
+++ b/OpenResourceSystem/ORSPlanetaryResourceMapData.cs
@@ -36,7 +36,7 @@ namespace OpenResourceSystem {
             body_resource_maps.Clear();
             body_abudnance_angles.Clear();
             map_body = -1;
-            current_body = -1;
+			current_body = body;
             foreach (UrlDir.UrlConfig config in configs) {
                 ConfigNode planetary_resource_config_node = config.config;
                 if (planetary_resource_config_node.GetValue("celestialBodyName") == celestial_body_name && planetary_resource_config_node != null) {
@@ -99,7 +99,6 @@ namespace OpenResourceSystem {
                     Debug.Log("[ORS] " + abundance_points_list.Count + " high value " + resource_gui_name + " locations detected");
                 }
             }
-            current_body = body;
         }
 
         protected static double getPixelAbundanceValue(int pix_x, int pix_y, ORSPlanetaryResourceInfo resource_info) {

--- a/OpenResourceSystem/ORSResourceScanner.cs
+++ b/OpenResourceSystem/ORSResourceScanner.cs
@@ -15,6 +15,7 @@ namespace OpenResourceSystem {
         public string Ab;
 
         protected double abundance = 0;
+		private ORSPlanetaryResourceInfo resourceInfo = null;
 
         [KSPEvent(guiActive = true, guiName = "Display Hotspots", active = true)]
         public void DisplayResource() {
@@ -32,17 +33,29 @@ namespace OpenResourceSystem {
         }
 
         public override void OnUpdate() {
+            ORSPlanetaryResourceMapData.updatePlanetaryResourceMap();
+			if (resourceInfo == null)
+				if (ORSPlanetaryResourceMapData.body_resource_maps.ContainsKey(resourceName))
+					resourceInfo = ORSPlanetaryResourceMapData.body_resource_maps[resourceName];
             Events["DisplayResource"].active = Events["DisplayResource"].guiActive = !ORSPlanetaryResourceMapData.resourceIsDisplayed(resourceName) && mapViewAvailable;
             Events["DisplayResource"].guiName = "Display " + resourceName + " hotspots";
             Events["HideResource"].active = Events["HideResource"].guiActive = ORSPlanetaryResourceMapData.resourceIsDisplayed(resourceName) && mapViewAvailable;
             Events["HideResource"].guiName = "Hide " + resourceName + " hotspots";
             Fields["Ab"].guiName = resourceName + " abundance";
-            if (abundance > 0.001) {
-                Ab = (abundance * 100.0).ToString("0.00") + "%";
-            } else {
-                Ab = (abundance * 1000000.0).ToString("0.0") + "ppm";
-            }
-            ORSPlanetaryResourceMapData.updatePlanetaryResourceMap();
+			if (resourceInfo != null)
+			{
+				if (resourceInfo.getResourceScale() == 1)
+				{
+					Ab = (abundance * 100.0).ToString("0.00") + "%";
+				}
+				else
+				{
+					Ab = (abundance * 1000000.0).ToString("0.0") + "ppm";
+				}
+			}
+			else
+				Ab = "Broken:(";
+
         }
 
         public override void OnFixedUpdate() {


### PR DESCRIPTION
This fixes three of the dumb, obvious issues that ORS has.
- The first one, a minor issue, is fixing the way it displays resource concentrations in the scanner context menu.
- The next, a major one, is preventing duplicate resource info keys from being added to the map dictionary. This solves, or at least reduces the effect of the duplicate resource problem. It will only load the first config that it comes across, but at least it won't implode if people put two resources with the same name in.
  - I also made sure that loading only takes place once per planet; if something goes wrong, repeatedly loading info from the configs is unlikely to fix it.
- The third issue, another major one, but somewhat harder to come across, is the problem of texture managing mods making the map textures unreadable. This isn't a great solution, it just tests the texture to make sure it can be accessed using the same method that other ORS functions use. If it doesn't work it just skips the rest of that resource config and moves on to the next.
