### PR TITLE
More ORS 1.3 changes

### DIFF
--- a/OpenResourceSystem/ORSPlanetaryResourceInfo.cs
+++ b/OpenResourceSystem/ORSPlanetaryResourceInfo.cs
@@ -18,6 +18,8 @@ namespace OpenResourceSystem {
         protected double scale_multiplier = 1;
         protected string displayTexture = "";
         protected double displayThreshold = 0.001;
+		private Color lowColor = XKCDColors.HotPink;
+		private Color highColor = XKCDColors.Fuchsia;
         
         public ORSPlanetaryResourceInfo(string name, Texture2D map, int body) {
             this.name = name;
@@ -57,6 +59,16 @@ namespace OpenResourceSystem {
             }
         }
 
+		public void setLowColor(string color)
+		{
+			this.lowColor = ConfigNode.ParseColor(color);
+		}
+
+		public void setHighColor(string color)
+		{
+			this.highColor = ConfigNode.ParseColor(color);
+		}
+
         public int getBody() {
             return body;
         }
@@ -92,5 +104,15 @@ namespace OpenResourceSystem {
         public double getScaleMultiplier() {
             return scale_multiplier;
         }
+
+		public Color getLowColor()
+		{
+			return lowColor;
+		}
+
+		public Color getHighColor()
+		{
+			return highColor;
+		}
     }
 }

--- a/OpenResourceSystem/ORSPlanetaryResourceInfo.cs
+++ b/OpenResourceSystem/ORSPlanetaryResourceInfo.cs
@@ -20,6 +20,7 @@ namespace OpenResourceSystem {
         protected double displayThreshold = 0.001;
 		private Color lowColor = XKCDColors.HotPink;
 		private Color highColor = XKCDColors.Fuchsia;
+		private bool hidden = false;
         
         public ORSPlanetaryResourceInfo(string name, Texture2D map, int body) {
             this.name = name;
@@ -69,6 +70,11 @@ namespace OpenResourceSystem {
 			this.highColor = ConfigNode.ParseColor(color);
 		}
 
+		public void setHiddenValue(string s)
+		{
+			this.hidden = bool.Parse(s);
+		}
+
         public int getBody() {
             return body;
         }
@@ -113,6 +119,11 @@ namespace OpenResourceSystem {
 		public Color getHighColor()
 		{
 			return highColor;
+		}
+
+		public bool getHidden()
+		{
+			return hidden;
 		}
     }
 }

--- a/OpenResourceSystem/ORSPlanetaryResourceMapData.cs
+++ b/OpenResourceSystem/ORSPlanetaryResourceMapData.cs
@@ -103,6 +103,16 @@ namespace OpenResourceSystem
                         double display_threshold = double.Parse(display_threshold_str);
                         resource_info.setDisplayThreshold(display_threshold);
                     }
+					if (planetary_resource_config_node.HasValue("lowColor"))
+					{
+						string lowColor = planetary_resource_config_node.GetValue("lowColor");
+						resource_info.setLowColor(lowColor);
+					}
+					if (planetary_resource_config_node.HasValue("highColor"))
+					{
+						string highColor = planetary_resource_config_node.GetValue("highColor");
+						resource_info.setHighColor(highColor);
+					}
                     body_resource_maps.Add(resource_gui_name, resource_info);
                     List<Vector2d> abundance_points_list = new List<Vector2d>();
 

--- a/OpenResourceSystem/ORSPlanetaryResourceMapData.cs
+++ b/OpenResourceSystem/ORSPlanetaryResourceMapData.cs
@@ -113,6 +113,11 @@ namespace OpenResourceSystem
 						string highColor = planetary_resource_config_node.GetValue("highColor");
 						resource_info.setHighColor(highColor);
 					}
+					if (planetary_resource_config_node.HasValue("hidden"))
+					{
+						string hidden = planetary_resource_config_node.GetValue("hidden");
+						resource_info.setHiddenValue(hidden);
+					}
                     body_resource_maps.Add(resource_gui_name, resource_info);
                     List<Vector2d> abundance_points_list = new List<Vector2d>();
 

--- a/OpenResourceSystem/ORSPlanetaryResourceMapData.cs
+++ b/OpenResourceSystem/ORSPlanetaryResourceMapData.cs
@@ -94,7 +94,7 @@ namespace OpenResourceSystem
                     }
                     else
                     {
-                        string tex_path = planetary_resource_config_node.GetValue("WarpPlugin/resource_point");
+                        string tex_path = planetary_resource_config_node.GetValue("OpenResourceSystem/resource_point");
                         resource_info.setDisplayTexture(tex_path);
                     }
                     if (planetary_resource_config_node.HasValue("displayThreshold"))


### PR DESCRIPTION
This adds three more optional fields to the planetary resource nodes.

The low and highColor values can be used to specify color ranges for map overlays; these work the same as how Kethane resources define their colors.

The other is a hidden flag, which will simplify making resources not meant to be displayed on overlays. It could also be used to prevent ORS scanners from detecting them, but that will require changes to the ORS scanner module. It defaults to false, so it doesn't need to be included in the resource definition unless you want to flag something as hidden.
